### PR TITLE
Fix missing region error for providers

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,10 @@
 provider "aws" {
   alias = "accepter"
+  region = var.accepter_region
 }
 
 provider "aws" {
   alias = "requester"
+  region = var.requester_region
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,13 @@ variable "route_ipv6" {
   type        = string
 }
 
+variable "requester_region" {
+  description = "Requester VPC region"
+  type = string
+}
+
+variable "accepter_region" {
+  description = "Accepter VPC region"
+  type = string
+}
+


### PR DESCRIPTION
Error:
```
$ terraform plan

Error: Missing required argument

  on .terraform/modules/vpc_peering/QuiNovas-terraform-aws-vpc-peering-78d80a8/providers.tf line 1, in provider "aws":
   1: provider "aws" {

The argument "region" is required, but no definition was found.


Error: Missing required argument

  on .terraform/modules/vpc_peering/QuiNovas-terraform-aws-vpc-peering-78d80a8/providers.tf line 5, in provider "aws":
   5: provider "aws" {

The argument "region" is required, but no definition was found.

Releasing state lock. This may take a few moments...
```

Terraform version: v0.12.21