### PR TITLE
Use configuration aliases

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ resource "aws_vpc_peering_connection_accepter" "accepter" {
 
 resource "aws_vpc_peering_connection_options" "accepter" {
   accepter {
-      allow_classic_link_to_remote_vpc = lookup(var.accepter_options, "allow_classic_link_to_remote_vpc", false)
-      allow_remote_vpc_dns_resolution  = lookup(var.accepter_options, "allow_remote_vpc_dns_resolution", false)
-      allow_vpc_to_remote_classic_link = lookup(var.accepter_options, "allow_vpc_to_remote_classic_link", false)
-    }
+    allow_classic_link_to_remote_vpc = lookup(var.accepter_options, "allow_classic_link_to_remote_vpc", false)
+    allow_remote_vpc_dns_resolution  = lookup(var.accepter_options, "allow_remote_vpc_dns_resolution", false)
+    allow_vpc_to_remote_classic_link = lookup(var.accepter_options, "allow_vpc_to_remote_classic_link", false)
+  }
   count                     = length(keys(var.accepter_options)) > 0 ? 1 : 0
   provider                  = aws.accepter
   vpc_peering_connection_id = aws_vpc_peering_connection.connection.id
@@ -28,10 +28,10 @@ resource "aws_vpc_peering_connection_options" "accepter" {
 
 resource "aws_vpc_peering_connection_options" "requester" {
   accepter {
-      allow_classic_link_to_remote_vpc = lookup(var.requester_options, "allow_classic_link_to_remote_vpc", false)
-      allow_remote_vpc_dns_resolution  = lookup(var.requester_options, "allow_remote_vpc_dns_resolution", false)
-      allow_vpc_to_remote_classic_link = lookup(var.requester_options, "allow_vpc_to_remote_classic_link", false)
-    }
+    allow_classic_link_to_remote_vpc = lookup(var.requester_options, "allow_classic_link_to_remote_vpc", false)
+    allow_remote_vpc_dns_resolution  = lookup(var.requester_options, "allow_remote_vpc_dns_resolution", false)
+    allow_vpc_to_remote_classic_link = lookup(var.requester_options, "allow_vpc_to_remote_classic_link", false)
+  }
   count                     = length(keys(var.requester_options)) > 0 ? 1 : 0
   provider                  = aws.requester
   vpc_peering_connection_id = aws_vpc_peering_connection.connection.id

--- a/providers.tf
+++ b/providers.tf
@@ -1,14 +1,7 @@
-terraform {
-  required_version = ">= 0.13"
+provider "aws" {
+  alias = "accepter"
+}
 
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-
-      configuration_aliases = [
-        aws.accepter,
-        aws.requester,
-      ]
-    }
-  }
+provider "aws" {
+  alias = "requester"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,14 @@
-provider "aws" {
-  alias = "accepter"
-}
+terraform {
+  required_version = ">= 0.13"
 
-provider "aws" {
-  alias = "requester"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+
+      configuration_aliases = [
+        aws.accepter,
+        aws.requester,
+      ]
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "accepter_options" {
   default     = {}
   description = "An optional configuration block that allows for VPC Peering Connection options to be set for the VPC that accepts the peering connection (a maximum of one)."
-  type = map(string)
+  type        = map(string)
 }
 
 variable "accepter_route_table_ids" {
@@ -24,7 +24,7 @@ variable "accepter_vpc_id" {
 variable "requester_options" {
   default     = {}
   description = "A optional configuration block that allows for VPC Peering Connection options to be set for the VPC that requests the peering connection (a maximum of one)."
-  type = map(string)
+  type        = map(string)
 }
 
 variable "requester_route_table_ids" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,0 @@
-
-terraform {
-  required_version = ">= 0.13"
-  required_providers {
-    aws = {
-      source = "hashicorp/aws"
-    }
-  }
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+
+      configuration_aliases = [
+        aws.accepter,
+        aws.requester,
+      ]
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
+      source = "hashicorp/aws"
 
       configuration_aliases = [
         aws.accepter,


### PR DESCRIPTION
This pull request should remove a 'legacy providers' warning in Terraform.