### PR TITLE
Remove redundant empty provider block

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  alias = "accepter"
-}
-
-provider "aws" {
-  alias = "requester"
-}


### PR DESCRIPTION
Hi, 

I still get the same warning message in 3.0.4.
<img width="909" alt="image" src="https://user-images.githubusercontent.com/1439383/196715230-243571f5-0456-4d0d-af95-17f881a479a3.png">

This pull request should fix the above warning.
