### PR TITLE
Revert "Remove redundant empty provider block"

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  alias = "accepter"
+}
+
+provider "aws" {
+  alias = "requester"
+}


### PR DESCRIPTION
Reverts QuiNovas/terraform-aws-vpc-peering#15