### PR TITLE
Remove deprecated parameters and providers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,9 +17,7 @@ resource "aws_vpc_peering_connection_accepter" "accepter" {
 
 resource "aws_vpc_peering_connection_options" "accepter" {
   accepter {
-    allow_classic_link_to_remote_vpc = lookup(var.accepter_options, "allow_classic_link_to_remote_vpc", false)
     allow_remote_vpc_dns_resolution  = lookup(var.accepter_options, "allow_remote_vpc_dns_resolution", false)
-    allow_vpc_to_remote_classic_link = lookup(var.accepter_options, "allow_vpc_to_remote_classic_link", false)
   }
   count                     = length(keys(var.accepter_options)) > 0 ? 1 : 0
   provider                  = aws.accepter
@@ -28,9 +26,7 @@ resource "aws_vpc_peering_connection_options" "accepter" {
 
 resource "aws_vpc_peering_connection_options" "requester" {
   accepter {
-    allow_classic_link_to_remote_vpc = lookup(var.requester_options, "allow_classic_link_to_remote_vpc", false)
     allow_remote_vpc_dns_resolution  = lookup(var.requester_options, "allow_remote_vpc_dns_resolution", false)
-    allow_vpc_to_remote_classic_link = lookup(var.requester_options, "allow_vpc_to_remote_classic_link", false)
   }
   count                     = length(keys(var.requester_options)) > 0 ? 1 : 0
   provider                  = aws.requester

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 resource "aws_vpc_peering_connection" "connection" {
   auto_accept   = false
   peer_owner_id = data.aws_caller_identity.accepter.account_id
-  peer_region   = data.aws_region.accepter.name
+  peer_region   = data.aws_region.accepter.region
   peer_vpc_id   = data.aws_vpc.accepter.id
   provider      = aws.requester
   tags          = var.requester_tags

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  alias = "accepter"
-}
-
-provider "aws" {
-  alias = "requester"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 5.0"
 
       configuration_aliases = [
         aws.accepter,

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
 
       configuration_aliases = [
         aws.accepter,

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
 
       configuration_aliases = [
         aws.accepter,


### PR DESCRIPTION
Two changes here:
* Removed `allow_classic_link_to_remote_vpc` and `allow_vpc_to_remote_classic_link` parameters which are deprecated as of AWS provider `5.0`. I've also set this as a required version to prevent confusion.
* Remove empty `provider` blocks (per Terraform warnings) as this is no longer needed and is deprecated.
Relevant warning:
> Earlier versions of Terraform used empty provider blocks ("proxy provider configurations") for child modules to declare their need to be passed a provider configuration by their callers. That approach was ambiguous and is now deprecated.